### PR TITLE
PRC-45: changed to use ppieross Container ID exclusively

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -9,9 +9,6 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<link rel="icon" type="image/x-icon" href="./favicon.ico">
 
-	<!-- NOTE: use Container ID 'GTM-T9H54MV' for comment.nrs.gov.bc.ca -->
-	<!-- NOTE: use Container ID 'GTM-M9XRQCZ' for nrts-prc-dev.pathfinder.gov.bc.ca -->
-	<!-- NOTE: use Container ID 'GTM-M9XRQCZ' for nrts-prc-test.pathfinder.gov.bc.ca -->
 	<!-- Google Tag Manager -->
 	<script>(function (w, d, s, l, i) {
 			w[l] = w[l] || []; w[l].push({
@@ -20,7 +17,7 @@
 			}); var f = d.getElementsByTagName(s)[0],
 				j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
 					'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
-		})(window, document, 'script', 'dataLayer', 'GTM-M9XRQCZ');</script>
+		})(window, document, 'script', 'dataLayer', 'GTM-T9H54MV');</script>
 	<!-- End Google Tag Manager -->
 
 	<!-- Typekit -->


### PR DESCRIPTION
All PRC Public sites (Dev/Test/Prod) go to Ola's container, where they are associated with a Tracking ID per hostname. (Other PRC Public sites -- ie, localhost -- go to Severin's container.)