### PR TITLE
[PRC-484] Limit size of Map Pop-up Interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "ngx-chips": "1.5.11",
     "ngx-cookie-service": "1.0.10",
     "ngx-pagination": "3.1.0",
+    "ngx-text-overflow-clamp": "0.0.1",
     "popper.js": "^1.14.1",
     "rxjs": "5.5.7",
     "web-animations-js": "^2.3.1",

--- a/src/app/applications/app-detail-popup/app-detail-popup.component.html
+++ b/src/app/applications/app-detail-popup/app-detail-popup.component.html
@@ -4,7 +4,7 @@
 </div>
 <div class="app-details">
   <div>
-    <span class="value">{{app?.description || '-'}}</span>
+    <div class="value" style="width: 100%;" [clamp]="4">{{app?.description || '-'}}</div>
   </div>
   <hr class="mt-3 mb-3">
   <ul class="nv-list mb-3">

--- a/src/app/shared.module.ts
+++ b/src/app/shared.module.ts
@@ -7,6 +7,7 @@ import { MatSnackBarModule } from '@angular/material';
 import { OrderByPipe } from 'app/pipes/order-by.pipe';
 import { NewlinesPipe } from 'app/pipes/newlines.pipe';
 import { ObjectFilterPipe } from 'app/pipes/object-filter.pipe';
+import { NgxTextOverflowClampModule } from 'ngx-text-overflow-clamp';
 
 import { VarDirective } from 'app/utils/ng-var.directive';
 import { DragMoveDirective } from 'app/utils/drag-move.directive';
@@ -16,7 +17,8 @@ import { DragMoveDirective } from 'app/utils/drag-move.directive';
     // CommonModule,
     BrowserModule,
     MatProgressBarModule,
-    MatSnackBarModule
+    MatSnackBarModule,
+    NgxTextOverflowClampModule
   ],
   declarations: [
     OrderByPipe,
@@ -28,6 +30,7 @@ import { DragMoveDirective } from 'app/utils/drag-move.directive';
   exports: [
     MatProgressBarModule,
     MatSnackBarModule,
+    NgxTextOverflowClampModule,
     OrderByPipe,
     NewlinesPipe,
     ObjectFilterPipe,


### PR DESCRIPTION
Adding the line clamp module so we can limit text blocks to a specific number of rows.