### PR TITLE
[PRC-706] Fix Header issue in Firefox

### DIFF
--- a/src/assets/styles/components/buttons.scss
+++ b/src/assets/styles/components/buttons.scss
@@ -66,6 +66,10 @@ main {
   border-radius: 0.2rem;
   transition: all ease-out 0.2s;
 
+  i {
+    vertical-align: middle;
+  }
+
   img, i, span {
     transition: all ease-out 0.2s;
   }
@@ -180,6 +184,10 @@ main {
   background: $gold;
   transform: translateY(1rem);
   transition: all ease-out 0.2s;
+
+  i {
+    vertical-align: middle;
+  }
 
   &.visible {
     opacity: 1;

--- a/src/assets/styles/components/hero-banner.scss
+++ b/src/assets/styles/components/hero-banner.scss
@@ -10,6 +10,7 @@
 
   .container {
     display: table;
+    height: 1px; // Fix Firefox - won't correnctly render min-height unless an initial value is added
     min-height: 20rem;
 
     &-inner {


### PR DESCRIPTION
Fixed a rendering issue with min-height and display: table in Firefox (banner would not size correctly)

Additional Fix
- Fixed vertical alignment of icons in the slide buttons and scroll top button.