### PR TITLE
[PRC-745] Mobile Popup Fixes

### DIFF
--- a/src/app/applications/applist-map/applist-map.component.scss
+++ b/src/app/applications/applist-map/applist-map.component.scss
@@ -52,9 +52,14 @@ $toggle-list-anim-duration: 0.2s;
     border-radius: 0.2rem;
   }
 
+  .leaflet-popup {
+    margin-bottom: 60px;
+  }
+
   .leaflet-popup-content {
     width: 20rem !important;
     margin: 0;
+    overflow: hidden;
   }
 
   .leaflet-popup-close-button {

--- a/src/app/applications/applist-map/applist-map.component.ts
+++ b/src/app/applications/applist-map/applist-map.component.ts
@@ -23,18 +23,19 @@ const L = window['L'];
 
 const markerIconYellow = L.icon({
   iconUrl: 'assets/images/marker-icon-yellow.svg',
-  iconRetinaUrl: 'assets/images/marker-icon-2x-yellow.svg',
-  iconSize: [25, 41],
-  iconAnchor: [12, 41],
-  popupAnchor: [1, -34],
+  // Retina Icon is not needed here considering we're using an SVG. Enable if you want to change to a raster asset.
+  // iconRetinaUrl: 'assets/images/marker-icon-2x-yellow.svg',
+  iconSize: [36, 36],
+  iconAnchor: [18, 36],
   tooltipAnchor: [16, -28]
 });
 
 const markerIconYellowLg = L.icon({
   iconUrl: 'assets/images/marker-icon-yellow-lg.svg',
-  iconRetinaUrl: 'assets/images/marker-icon-2x-yellow-lg.svg',
-  iconSize: [50, 82],
-  iconAnchor: [25, 82],
+  // Retina Icon is not needed here considering we're using an SVG. Enable if you want to change to a raster asset.
+  // iconRetinaUrl: 'assets/images/marker-icon-yellow-lg.svg',
+  iconSize: [48, 48],
+  iconAnchor: [24, 48],
   // popupAnchor: [1, -34], // TODO: update, if needed
   // tooltipAnchor: [16, -28] // TODO: update, if needed
 });
@@ -345,10 +346,9 @@ export class ApplistMapComponent implements AfterViewInit, OnChanges, OnDestroy 
     }
 
     const popupOptions = {
-      maxWidth: 400,
       className: 'map-popup-content',
-      autoPanPaddingTopLeft: L.point(40, 95),
-      autoPanPaddingBottomRight: L.point(60, 0)
+      autoPanPaddingTopLeft: L.point(40, 150),
+      autoPanPaddingBottomRight: L.point(40, 20)
     };
 
     // compile marker popup component
@@ -383,7 +383,6 @@ export class ApplistMapComponent implements AfterViewInit, OnChanges, OnDestroy 
       if (marker) {
         this.currentMarker = marker;
         marker.setIcon(markerIconYellowLg);
-        this.centerMap(marker.getLatLng());
         // FUTURE: zoom in to this app/marker ?
         // FUTURE: show the marker popup ?
         // this.onMarkerClick(app, { target: marker });


### PR DESCRIPTION
Fixed some issues with the map popup and leaflet properties not obeying the height of the component.

- Added margin to the popup to allow visibility of the marker while the popup is still available
- Standardized the 'iconSize' properties for the map markers (easier to scale proportionately when calling larger sizes)
- Commented out 'iconRetinaSize' (don't require since we are using SVG assets here). 
- Added 'autoPan' and modified the boundary properties to ensure the popup appears within the viewport at all times (when enabled)