### PR TITLE
[PRC-731] Reposition Map Components

### DIFF
--- a/src/app/applications/applications.component.scss
+++ b/src/app/applications/applications.component.scss
@@ -73,10 +73,10 @@ app-applications:host {
 
 .toggle-app-list-btn {
   position: absolute;
-  top: 0.8rem;
-  right: -35px;
+  top: 0.5rem;
+  right: -39px;
   padding: 0;
-  width: 36px;
+  width: 40px;
   height: 3rem;
   z-index: 1003;
   box-shadow: $map-component-shadow;

--- a/src/app/applications/applist-map/applist-map.component.scss
+++ b/src/app/applications/applist-map/applist-map.component.scss
@@ -3,7 +3,6 @@
 $toggle-list-anim-duration: 0.2s;
 
 .map-container {
-  //@include flex(1 1 auto);
   position: absolute;
   top: 0;
   right: 0;
@@ -18,14 +17,10 @@ $toggle-list-anim-duration: 0.2s;
     left: 0;
     background-color: $map-bg;
     transition: left ease-out $toggle-list-anim-duration;
-
-    .leaflet-popup-content-wrapper {
-      border-radius: 4px;
-    }
   }
 }
 
-// Map Popup
+// Map Control Customization
 ::ng-deep {
   .leaflet-container {
     a.leaflet-popup-close-button {
@@ -46,14 +41,14 @@ $toggle-list-anim-duration: 0.2s;
       }
     }
   }
+
+  .leaflet-popup {
+    margin-bottom: 60px; // Offset so we can see the marker
+  }
   
   .leaflet-popup-content-wrapper {
     padding: 0;
     border-radius: 0.2rem;
-  }
-
-  .leaflet-popup {
-    margin-bottom: 60px;
   }
 
   .leaflet-popup-content {
@@ -62,8 +57,77 @@ $toggle-list-anim-duration: 0.2s;
     overflow: hidden;
   }
 
-  .leaflet-popup-close-button {
-    font-size: 2rem;
+  .leaflet-control-attribution {
+    padding: 0.5rem;
+    height: 4rem;
+    line-height: 0.75rem;
+    font-size: 0.75rem;
+  }
+
+  .leaflet-bottom.leaflet-left {
+    bottom: 4.25rem;
+  }
+
+  .map-reset-control {
+    margin-right: 12px !important;
+    padding: 0;
+    width: 30px;
+    height: 30px;
+    background: #fff;
+    text-align: center;
+    line-height: 30px;
+    border-radius: 2px;
+    border: none;
+    box-shadow: 0 0 0 2px rgba(0,0,0,0.2);
+    cursor: pointer;
+
+    &:hover {
+      background: #f4f4f4;
+    }
+  }
+}
+
+@media (min-width: 377px) {
+  ::ng-deep {
+    .leaflet-bottom.leaflet-left {
+      bottom: 3.5rem;
+    }
+
+    .leaflet-control-attribution {
+      height: 3.25rem ;
+    }
+  }
+}
+
+@media (min-width: 570px) {
+  ::ng-deep {
+    .leaflet-bottom.leaflet-left {
+      bottom: 2.75rem;
+    }
+
+    .leaflet-control-attribution {
+      height: 2.5rem;
+    }
+  }
+}
+
+@media (min-width: 1085px){
+  ::ng-deep {
+    .leaflet-bottom.leaflet-left {
+      bottom: 2rem;
+    }
+
+    .leaflet-control-attribution {
+      height: auto;
+    }
+  }
+}
+
+@media (min-width: 1175px) {
+  ::ng-deep {
+    .leaflet-bottom.leaflet-left {
+      bottom: 0;
+    }
   }
 }
 

--- a/src/app/applications/applist-map/applist-map.component.ts
+++ b/src/app/applications/applist-map/applist-map.component.ts
@@ -88,20 +88,16 @@ export class ApplistMapComponent implements AfterViewInit, OnChanges, OnDestroy 
 
     // custom control to reset map view
     const resetViewControl = L.Control.extend({
+      options: {
+        position: 'bottomright'
+      },
       onAdd: function () {
-        const element = L.DomUtil.create('i', 'material-icons leaflet-bar leaflet-control leaflet-control-custom');
+        const element = L.DomUtil.create('button');
 
         element.title = 'Reset view';
         element.innerText = 'refresh'; // material icon name
-        element.style.width = '34px';
-        element.style.height = '34px';
-        element.style.lineHeight = '30px';
-        element.style.textAlign = 'center';
-        element.style.cursor = 'pointer';
-        element.style.backgroundColor = '#fff';
-        element.onmouseover = () => element.style.backgroundColor = '#f4f4f4';
-        element.onmouseout = () => element.style.backgroundColor = '#fff';
         element.onclick = () => self.resetView();
+        element.className = 'material-icons map-reset-control';
 
         // prevent underlying map actions for these events
         L.DomEvent.disableClickPropagation(element); // includes double-click
@@ -140,7 +136,8 @@ export class ApplistMapComponent implements AfterViewInit, OnChanges, OnDestroy 
     this.map = L.map('map', {
       zoomControl: false, // will be added manually below
       maxBounds: L.latLngBounds(L.latLng(-90, -180), L.latLng(90, 180)), // restrict view to "the world"
-      zoomSnap: 0.1 // for greater granularity when fitting bounds
+      zoomSnap: 0.1, // for greater granularity when fitting bounds
+      attributionControl: false
     });
 
     // map state change events
@@ -165,14 +162,6 @@ export class ApplistMapComponent implements AfterViewInit, OnChanges, OnDestroy 
     // add markers group
     this.map.addLayer(this.markerClusterGroup);
 
-    // add reset view control
-    this.map.addControl(new resetViewControl());
-
-    // add zoom control
-    L.control.zoom({ position: 'topright' }).addTo(this.map);
-
-    // add scale control
-    L.control.scale({ position: 'bottomright' }).addTo(this.map);
 
     // add base maps layers control
     const baseLayers = {
@@ -182,7 +171,19 @@ export class ApplistMapComponent implements AfterViewInit, OnChanges, OnDestroy 
       'World Topographic': World_Topo_Map,
       'World Imagery': World_Imagery
     };
-    L.control.layers(baseLayers).addTo(this.map);
+    L.control.layers(baseLayers, null, { position: 'topright' }).addTo(this.map);
+
+    // map attribution
+    L.control.attribution({position: 'bottomright'}).addTo(this.map);
+
+    // add scale control
+    L.control.scale({ position: 'bottomleft' }).addTo(this.map);
+
+    // add zoom control
+    L.control.zoom({ position: 'bottomright' }).addTo(this.map);
+
+    // add reset view control
+    this.map.addControl(new resetViewControl());
 
     // load base layer
     for (const key of Object.keys(baseLayers)) {


### PR DESCRIPTION
Re-positioned the map controls - more consistent with widely adopted design patterns / interface paradigms

Additional Fixes
- Clean-up selectors/styling
- Removed unused or incorrect selectors
- Changed the map reset component to an element that can be focused and tab-indexed
- Removed styling of the map reset component from the typescript file into the stylesheet